### PR TITLE
[chore] move optional dependencies to devDepedendency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-promise": "4.3.1",
-    "husky": "^3.0.0"
+    "husky": "^3.0.0",
     "prettier": "1.19.1",
     "qunit": "2.9.3",
     "qunit-decorators": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@commitlint/cli": "8.3.5",
+    "@commitlint/config-conventional": "8.3.4",
     "@microsoft/api-documenter": "7.8.17",
     "@microsoft/api-extractor": "7.9.0",
+    "@mike-north/js-lib-renovate-config": "1.3.1",
     "@types/qunit": "2.9.1",
     "@typescript-eslint/eslint-plugin": "2.30.0",
     "@typescript-eslint/parser": "2.30.0",
@@ -30,18 +33,13 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-promise": "4.3.1",
+    "husky": "^3.0.0"
     "prettier": "1.19.1",
     "qunit": "2.9.3",
     "qunit-decorators": "1.1.5",
     "rimraf": "3.0.2",
     "scripty": "1.9.1",
     "typescript": "3.7.5"
-  },
-  "optionalDependencies": {
-    "@commitlint/cli": "8.3.5",
-    "@commitlint/config-conventional": "8.3.4",
-    "@mike-north/js-lib-renovate-config": "1.3.1",
-    "husky": "^3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Summary

Started a PR here https://github.com/mike-north/devcert/pull/190 this should resolve the problem for any consumers of this to ensure husky is not installed and ran as a part of the consumers git hooks.